### PR TITLE
Fix signup flow logic to correctly show signup form only when not authenticated

### DIFF
--- a/frontend/app/auth/signup/signup-client.tsx
+++ b/frontend/app/auth/signup/signup-client.tsx
@@ -16,8 +16,9 @@ export default function SignupClient() {
         if (!authLoading) {
             if (isAuthenticated && user) {
                 router.replace("/dashboard")
+            } else {
+                setShowSignupForm(true)
             }
-            setShowSignupForm(true)
         }
     }, [isAuthenticated, authLoading, router, user])
 


### PR DESCRIPTION
This pull request includes a small change to the `SignupClient` function in the `frontend/app/auth/signup/signup-client.tsx` file. The change fixes the logic to ensure the signup form is shown when the user is not authenticated and `authLoading` is false.…henticated