### PR TITLE
Redirect to login instead of dashboard on successful signup without verification

### DIFF
--- a/frontend/components/auth/auth-provider.tsx
+++ b/frontend/components/auth/auth-provider.tsx
@@ -131,11 +131,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         // Case 1: Verification required - show success page
         router.push(`/auth/signup-success?verification=true`);
       } else {
-        // Case 2: No verification needed - set auth state and redirect to dashboard
-        setUser(data.user);
-        setIsAuthenticated(true);
-        setIsAdmin(data.user.is_staff);
-        router.push(ROUTES.DASHBOARD);
+        // Case 2: No verification needed - set auth state and redirect to login
+        // setUser(data.user);
+        // setIsAuthenticated(true);
+        // setIsAdmin(data.user.is_staff);
+        router.push(ROUTES.LOGIN);
       }
 
       return data.user || null;


### PR DESCRIPTION
This pull request modifies the behavior of the `AuthProvider` component to change the redirection flow when no verification is needed. Instead of setting the authentication state and redirecting to the dashboard, the user is now redirected to the login page.

* **Change in redirection flow**:
  - In `frontend/components/auth/auth-provider.tsx`, the logic for handling the "no verification needed" case was updated. The lines setting the user state (`setUser`, `setIsAuthenticated`, `setIsAdmin`) were commented out, and the redirection was changed from `ROUTES.DASHBOARD` to `ROUTES.LOGIN`.…erification